### PR TITLE
Find multiple items or merchants

### DIFF
--- a/app/controllers/api/v1/items/find_controller.rb
+++ b/app/controllers/api/v1/items/find_controller.rb
@@ -1,16 +1,31 @@
 class Api::V1::Items::FindController < ApplicationController
   def show
-    if item_params_string.present?
-      item = Item.search_by_string(item_params_string)
-    elsif item_params_num.present?
-      item = Item.search_by_num(item_params_num)
-    else
-      item = Item.search_by_date(item_params_date)
-    end
+    item = if item_params_string.present?
+             Item.search_single_by_string(item_params_string)
+           elsif item_params_num.present?
+             Item.search_single_by_num(item_params_num)
+           else
+             Item.search_single_by_date(item_params_date)
+           end
     if item.nil?
       record_not_found
     else
       render json: ItemSerializer.new(item)
+    end
+  end
+
+  def index
+    items = if item_params_string.present?
+              Item.search_multiple_by_string(item_params_string)
+            elsif item_params_num.present?
+              Item.search_multiple_by_num(item_params_num)
+            else
+              Item.search_multiple_by_date(item_params_date)
+            end
+    if items.empty?
+      record_not_found
+    else
+      render json: ItemSerializer.new(items)
     end
   end
 

--- a/app/controllers/api/v1/merchants/find_controller.rb
+++ b/app/controllers/api/v1/merchants/find_controller.rb
@@ -1,16 +1,31 @@
 class Api::V1::Merchants::FindController < ApplicationController
   def show
-    if merchant_params_string.present?
-      merchant = Merchant.search_by_string(merchant_params_string)
-    elsif merchant_params_num.present?
-      merchant = Merchant.search_by_num(merchant_params_num)
-    else
-      merchant = Merchant.search_by_date(merchant_params_date)
-    end
+    merchant = if merchant_params_string.present?
+                 Merchant.search_single_by_string(merchant_params_string)
+               elsif merchant_params_num.present?
+                 Merchant.search_single_by_num(merchant_params_num)
+               else
+                 Merchant.search_single_by_date(merchant_params_date)
+               end
     if merchant.nil?
       record_not_found
     else
       render json: MerchantSerializer.new(merchant)
+    end
+  end
+
+  def index
+    merchants = if merchant_params_string.present?
+                  Merchant.search_multiple_by_string(merchant_params_string)
+                elsif merchant_params_num.present?
+                  Merchant.search_multiple_by_num(merchant_params_num)
+                else
+                  Merchant.search_multiple_by_date(merchant_params_date)
+                end
+    if merchants.empty?
+      record_not_found
+    else
+      render json: MerchantSerializer.new(merchants)
     end
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,19 +9,35 @@ class Item < ApplicationRecord
   validates :unit_price, presence: true
   validates :merchant_id, presence: true
 
-  def self.search_by_string(params)
+  def self.search_single_by_string(params)
     find_by("lower(#{params.keys.first}) like ?", "%#{params.values.first.downcase}%")
   end
 
-  def self.search_by_num(params)
+  def self.search_single_by_num(params)
     where("#{params.keys.first} = #{params.values.first}").first
   end
 
-  def self.search_by_date(params)
+  def self.search_single_by_date(params)
     if params[:created_at].present?
       find_by_created_at(params[:created_at])
     else
       find_by_updated_at(params[:updated_at])
+    end
+  end
+
+  def self.search_multiple_by_string(params)
+    where("lower(#{params.keys.first}) like ?", "%#{params.values.first.downcase}%")
+  end
+
+  def self.search_multiple_by_num(params)
+    where("#{params.keys.first} = #{params.values.first}")
+  end
+
+  def self.search_multiple_by_date(params)
+    if params[:created_at].present?
+      where(created_at: params[:created_at])
+    else
+      where(updated_at: params[:updated_at])
     end
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -7,19 +7,35 @@ class Merchant < ApplicationRecord
 
   validates :name, presence: true
 
-  def self.search_by_string(params)
+  def self.search_single_by_string(params)
     find_by("lower(#{params.keys.first}) like ?", "%#{params.values.first.downcase}%")
   end
 
-  def self.search_by_num(params)
+  def self.search_single_by_num(params)
     where("#{params.keys.first} = #{params.values.first}").first
   end
 
-  def self.search_by_date(params)
+  def self.search_single_by_date(params)
     if params[:created_at].present?
       find_by_created_at(params[:created_at])
     else
       find_by_updated_at(params[:updated_at])
+    end
+  end
+
+  def self.search_multiple_by_string(params)
+    where("lower(#{params.keys.first}) like ?", "%#{params.values.first.downcase}%")
+  end
+
+  def self.search_multiple_by_num(params)
+    where("#{params.keys.first} = #{params.values.first}")
+  end
+
+  def self.search_multiple_by_date(params)
+    if params[:created_at].present?
+      where(created_at: params[:created_at])
+    else
+      where(updated_at: params[:updated_at])
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,12 +5,14 @@ Rails.application.routes.draw do
       namespace :items do
         get '/:id/merchant', to: 'merchants#show'
         get '/find', to: 'find#show'
+        get '/find_all', to: 'find#index'
       end
       resources :items, only: %i[show index create destroy update]
 
       namespace :merchants do
         get '/:id/items', to: 'items#index'
         get '/find', to: 'find#show'
+        get '/find_all', to: 'find#index'
       end
       resources :merchants, only: %i[show index create destroy update]
     end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -226,5 +226,87 @@ RSpec.describe 'Api::V1::Items', type: :request do
 
       expect(response).to have_http_status(404)
     end
+    it "can find a list of items by name that contain a fragment, case insensitive" do
+      get '/api/v1/items/find_all?name=haru'
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      names = json[:data].map do |item|
+        item[:attributes][:name].downcase
+      end
+
+      expect(names.count).to eq(18)
+      names.each do |name|
+        expect(name).to include('haru')
+      end
+    end
+    it "can find a list of items by description that contain a fragment, case insensitive" do
+      get '/api/v1/items/find_all?description=nesc'
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      descriptions = json[:data].map do |item|
+        item[:attributes][:description].downcase
+      end
+
+      expect(descriptions.count).to eq(208)
+      descriptions.each do |description|
+        expect(description).to include('nesc')
+      end
+    end
+    it "can find a list of items by unit price" do
+      get '/api/v1/items/find_all?unit_price=751.07'
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      unit_prices = json[:data].map do |item|
+        item[:attributes][:unit_price]
+      end
+
+      expect(unit_prices.count).to eq(2)
+      unit_prices.each do |unit_price|
+        expect(unit_price).to eq(751.07)
+      end
+    end
+    it "can find a list of items by merchant id" do
+      get '/api/v1/items/find_all?merchant_id=5'
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      merchant_ids = json[:data].map do |item|
+        item[:attributes][:merchant_id]
+      end
+
+      expect(merchant_ids.count).to eq(11)
+      merchant_ids.each do |merchant_id|
+        expect(merchant_id).to eq(5)
+      end
+    end
+    it "can find a list of items by id" do
+      get '/api/v1/items/find_all?id=5'
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      ids = json[:data].map do |item|
+        item[:attributes][:id]
+      end
+
+      expect(ids.count).to eq(1)
+      ids.each do |id|
+        expect(id).to eq(5)
+      end
+    end
+    it "can find a list of items by created_at" do
+      get '/api/v1/items/find_all?created_at=2012-03-27 14:53:59 UTC'
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      expect(json[:data].count).to eq(170)
+    end
+    it "can find a list of items by updated_at" do
+      get '/api/v1/items/find_all?updated_at=2012-03-27 14:53:59 UTC'
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      expect(json[:data].count).to eq(170)
+    end
+    it 'will error if the find_all params are incorrect' do
+      get '/api/v1/items/find_all?name=zzzzzzzzz'
+
+      expect(response).to have_http_status(404)
+    end
   end
 end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -148,10 +148,50 @@ RSpec.describe 'Api::V1::Merchants', type: :request do
 
       expect(json[:data]).to be_a(Hash)
     end
-    it 'will error if the params are incorrect' do
+    it 'will error if the find params are incorrect' do
       get '/api/v1/merchants/find?id=9999999'
 
       expect(response).to have_http_status(404)
     end
+  end
+  it "can find a list of merchants by name that contain a fragment, case insensitive" do
+    get '/api/v1/merchants/find_all?name=ILL'
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    names = json[:data].map do |merchant|
+      merchant[:attributes][:name]
+    end
+
+    expect(names.sort).to eq(["Schiller, Barrows and Parker", "Tillman Group", "Williamson Group", "Williamson Group", "Willms and Sons"])
+  end
+  it "can find a list of merchants by id" do
+    get '/api/v1/merchants/find_all?id=5'
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    ids = json[:data].map do |item|
+      item[:attributes][:id]
+    end
+
+    expect(ids.count).to eq(1)
+    ids.each do |id|
+      expect(id).to eq(5)
+    end
+  end
+  it "can find a list of merchants by created_at" do
+    get '/api/v1/merchants/find_all?created_at=2012-03-27 14:53:59 UTC'
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(json[:data].count).to eq(9)
+  end
+  it "can find a list of merchants by updated_at" do
+    get '/api/v1/merchants/find_all?updated_at=2012-03-27 14:53:59 UTC'
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(json[:data].count).to eq(8)
+  end
+  it 'will error if the find_all params are incorrect' do
+    get '/api/v1/merchants/find_all?name=zzzzzzzzz'
+
+    expect(response).to have_http_status(404)
   end
 end


### PR DESCRIPTION
## All Submissions:

### Issues

Resolves #11 #30 

- Add functionality to make an API call to return multiple merchants or items based on a query param which is an attribute of that table.
- Example URI: `items/find_all?name=haru`
- For strings, this is a fuzzy search meaning it will return a match which includes the string searched for and does not have to be exact.
- For non-strings, this has to be an exact match. For example, items/find_all?id=1 will only return an item with an id of 1, and will not return an item that has an id of 12 or 21.

### New Feature Submissions:

* [X] Have you added an explanation of what your changes do?
* [X] Have you lint your code locally prior to submission?

### Testing:

* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
* [X] All new and existing tests passed?

**Test coverage** = 100%
--------------------------------------------------------------------------------
### Change Log:
